### PR TITLE
Mejorada transparencia en hover de button_di-buffala

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -54,8 +54,8 @@ p {
 }
 
 .button_di-buffala:hover {
-  background-color: hsla(227, 100%, 60%, .1);
-  color: #325DFF;
+  background-color: hsla(227, 100%, 60%, .75);
+  color: #ffffff;
 }
 
 /* Navbar */


### PR DESCRIPTION
La transparencia del efecto hover en la clase para los botones principales es muy alta y el texto del botón se hace ilegible. Dejé la transparencia más sutil y el texto en blanco para mentener legibilidad.