### PR TITLE
Cambio de color de los iconos, para salir un poco del azul

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -197,7 +197,7 @@ p {
 }
 
 .features__inner-icon {
-  background-color: #325DFF;
+  background-color: #ffb732;
   border-radius: 50%;
   width: 100px;
   height: 100px;


### PR DESCRIPTION
**Los cambios realizados** fueron pensados para salir un poco del azul y resaltar el área de los iconos colocando el color anaranjados.