### PR TITLE
Cambio de colores en los iconos

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -197,7 +197,7 @@ p {
 }
 
 .features__inner-icon {
-  background-color: #325DFF;
+  background-color: #ffa632;
   border-radius: 50%;
   width: 100px;
   height: 100px;


### PR DESCRIPTION
**Se hizo este cambio basado** en que esta sobrecargado de azul, la página es limpia y clara pero quisimos resaltar con un color naranjo esta sección de los iconos.