### PR TITLE
Cambio en opacidad de heroimage y color de items cuando están en focus

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1,21 +1,26 @@
 /* Global Styles */
 
-h1, h2, h3 {
-  font-family: 'Lato', sans-serif;
+h1,
+h2,
+h3 {
+  font-family: "Lato", sans-serif;
 }
 
-p, li, a, small {
-  font-family: 'Poppins', sans-serif;
+p,
+li,
+a,
+small {
+  font-family: "Poppins", sans-serif;
 }
 
 /* Font hierarchy */
 
 h1 {
- font-size: 3em;
+  font-size: 3em;
 }
 
 h2 {
- font-size: 2.25em;
+  font-size: 2.25em;
 }
 
 h3 {
@@ -26,26 +31,24 @@ p {
   color: hsla(0, 0%, 0%, 0.8);
 }
 
-@media only screen and (max-width : 767px) {
-
+@media only screen and (max-width: 767px) {
   h1 {
-   font-size: 2em;
+    font-size: 2em;
   }
 
   h2 {
-   font-size: 1.625em;
+    font-size: 1.625em;
   }
 
   h3 {
     font-size: 1.375em;
   }
-
 }
 
 /* Button */
 
 .button_di-buffala {
-  background-color: #325DFF;
+  background-color: #325dff;
   border-radius: 30px;
   padding: 2rem 6rem;
   color: #fff;
@@ -54,14 +57,14 @@ p {
 }
 
 .button_di-buffala:hover {
-  background-color: hsla(227, 100%, 60%, .1);
-  color: #325DFF;
+  background-color: hsla(227, 100%, 60%, 0.1);
+  color: #325dff;
 }
 
 /* Navbar */
 
 .navbar_di-buffala {
-  background-color: #325DFF;
+  background-color: #325dff;
   color: hsla(0, 100%, 100%, 0.52);
 }
 .icon-bar {
@@ -72,14 +75,17 @@ p {
   max-width: 120px;
 }
 
-.navbar-nav > li > a{
+.navbar-nav > li > a {
   color: #fff;
   text-shadow: none;
   text-transform: uppercase;
 }
+.navbar-nav > li > a:focus {
+  color: #325dff;
+}
 .nav > li > a:hover {
   background-color: initial;
-  color: hsla(0, 0%, 100%, .5);
+  color: hsla(0, 0%, 100%, 0.5);
 }
 
 .navbar {
@@ -89,7 +95,12 @@ p {
 /* Header */
 
 .header_di-buffala {
-  background-image: url("../img/bg-header.jpg");
+  background-image: linear-gradient(
+      to bottom,
+      rgba(0, 0, 0, 0.5) 0%,
+      rgba(0, 0, 0, 0.5) 100%
+    ),
+    url("../img/bg-header.jpg");
   background-repeat: no-repeat;
   background-size: cover;
   text-align: center;
@@ -104,13 +115,12 @@ p {
 }
 
 .header_di-buffala p {
-  color: hsla(0, 0%, 100%, .8);
+  color: hsla(0, 0%, 100%, 0.8);
   line-height: 22px;
   padding: 1rem 30vw;
 }
 
-@media only screen and (max-width : 767px) {
-
+@media only screen and (max-width: 767px) {
   .header_di-buffala {
     height: 500px;
     padding-top: 100px;
@@ -124,7 +134,6 @@ p {
   .header_di-buffala p {
     padding: 1rem 4rem;
   }
-
 }
 
 /* Blog */
@@ -151,7 +160,7 @@ p {
   padding-right: 8vw;
 }
 
-@media only screen and (max-width : 767px) {
+@media only screen and (max-width: 767px) {
   .blog__inner {
     padding-top: 2vh;
     padding-left: 15vw;
@@ -181,8 +190,8 @@ p {
   padding: 1rem 15vw;
 }
 
-.features__inner{
-  border: 1px solid hsla(0, 0%, 0%, .1);
+.features__inner {
+  border: 1px solid hsla(0, 0%, 0%, 0.1);
   border-radius: 3px;
   padding: 5rem 0rem;
   margin: 3rem 1rem;
@@ -193,11 +202,11 @@ p {
 }
 
 .features__inner p {
-  padding: .5rem 5rem;
+  padding: 0.5rem 5rem;
 }
 
 .features__inner-icon {
-  background-color: #325DFF;
+  background-color: #325dff;
   border-radius: 50%;
   width: 100px;
   height: 100px;
@@ -205,7 +214,7 @@ p {
   position: relative;
 }
 
-.svg-inline--fa  {
+.svg-inline--fa {
   color: #fff;
   font-size: 40px;
   position: absolute;
@@ -213,8 +222,7 @@ p {
   right: 30px;
 }
 
-@media only screen and (max-width : 767px) {
-
+@media only screen and (max-width: 767px) {
   .features {
     padding-bottom: 4rem;
   }
@@ -237,7 +245,6 @@ p {
     font-size: 1.7em;
     padding-top: 1rem;
   }
-
 }
 
 /* Video */
@@ -263,8 +270,7 @@ p {
   color: #fff;
 }
 
-@media only screen and (max-width : 767px) {
-
+@media only screen and (max-width: 767px) {
   .video {
     padding-left: 0;
   }
@@ -281,7 +287,6 @@ p {
   .video__inner p {
     visibility: hidden;
   }
-
 }
 
 /* Portfolio */
@@ -333,8 +338,7 @@ p {
   background-image: url("../img/portfolio-3.jpg");
 }
 
-@media only screen and (max-width : 767px) {
-
+@media only screen and (max-width: 767px) {
   .portfolio {
     padding-top: 2rem;
     padding-bottom: 2rem;
@@ -368,17 +372,17 @@ p {
     padding: 1rem 8vw 1rem 0;
   }
 
-  .portfolio__inner__image-top, .portfolio__inner__image-middle, .portfolio__inner__image-bottom {
+  .portfolio__inner__image-top,
+  .portfolio__inner__image-middle,
+  .portfolio__inner__image-bottom {
     display: none;
   }
-
 }
 
 /* Footer */
 
-
 .footer_di-buffala {
-  background-color: #325DFF;
+  background-color: #325dff;
   padding: 5vw 1rem;
   text-align: center;
 }


### PR DESCRIPTION
Se añade opacidad a la imagen de fondo para distinguir de mejor manera el texto añadido en la hero image. 
De igual forma, cuando los links son clickeados el color de letra es igual al de fondo por lo cual se cambia el color de letra para distinguirla.
**Antes:**
![image](https://user-images.githubusercontent.com/82623312/122656669-b6c30d80-d12a-11eb-9cd0-80e5aab8d315.png)
**Despues:**
![image](https://user-images.githubusercontent.com/82623312/122656646-8bd8b980-d12a-11eb-85fb-09cb3933db4f.png)
