### PR TITLE
color en CSS en navbar, footer, button, y fa icons

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -45,7 +45,7 @@ p {
 /* Button */
 
 .button_di-buffala {
-  background-color: #325DFF;
+  background-color: #125E6A;
   border-radius: 30px;
   padding: 2rem 6rem;
   color: #fff;
@@ -55,13 +55,13 @@ p {
 
 .button_di-buffala:hover {
   background-color: hsla(227, 100%, 60%, .1);
-  color: #325DFF;
+  color:#125E6A;
 }
 
 /* Navbar */
 
 .navbar_di-buffala {
-  background-color: #325DFF;
+  background-color: #1D707D;
   color: hsla(0, 100%, 100%, 0.52);
 }
 .icon-bar {
@@ -197,7 +197,7 @@ p {
 }
 
 .features__inner-icon {
-  background-color: #325DFF;
+  background-color: #125E6A;
   border-radius: 50%;
   width: 100px;
   height: 100px;
@@ -378,7 +378,7 @@ p {
 
 
 .footer_di-buffala {
-  background-color: #325DFF;
+  background-color: #1D707D;
   padding: 5vw 1rem;
   text-align: center;
 }


### PR DESCRIPTION
se modificó el color del navbar, footer, button y fa icons de  #325DFF a #125E6A para bacgrounds y #1D707D para buttons e icons