### PR TITLE
Incorporación Links a redes sociales con iconos fontawesome

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -387,3 +387,9 @@ p {
   color: #fff;
   font-size: 1em;
 }
+
+.fab-link a {
+  padding: 2%;  
+  color:#fff;
+  font-size:4rem;
+}

--- a/index.html
+++ b/index.html
@@ -166,6 +166,16 @@
 <!-- hola -->
   <!-- Footer -->
   <footer class="footer_di-buffala">
+    <div class="fab-link">
+      <a href="http://www.github.com" target="_blank"><i class="fab fa-github-square px-2"
+              data-bs-toggle="tooltip" data-bs-placement="top" title="GitHub"></i></a>
+      <a href="http://www.linkedin.com" target="_blank"><i class="fab fa-linkedin px-2"
+              data-bs-toggle="tooltip" data-bs-placement="top" title="Linkedin"></i></a>
+      <a href="http://www.twitter.com" target="_blank"><i class="fab fa-twitter-square px-2"
+              data-bs-toggle="tooltip" data-bs-placement="top" title="Twitter"></i></a>
+      <a href="http://www.facebook.com" target="_blank"><i class="fab fa-facebook-square px-2"
+              data-bs-toggle="tooltip" data-bs-placement="top" title="Facebook"></i></a>
+  </div>            
     <small>DiBufalla 2018. Todos los derechos reservados.</small>
   </footer>
 
@@ -174,8 +184,10 @@
   <script src="https://code.jquery.com/jquery-3.3.1.slim.js" integrity="sha256-fNXJFIlca05BIO2Y5zh1xrShK3ME+/lYZ0j+ChxX2DA=" crossorigin="anonymous"></script>
   <!-- Latest compiled and minified JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
-  <!-- Font Awesome 5 -->
-  <script defer src="https://use.fontawesome.com/releases/v5.0.8/js/all.js" integrity="sha384-SlE991lGASHoBfWbelyBPLsUlwY1GwNDJo3jSJO04KZ33K2bwfV9YBauFfnzvynJ" crossorigin="anonymous"></script>
+  
+   <!-- FontAwesome 5.15.4 -->
+   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.4/css/all.css"
+   integrity="sha384-DyZ88mC6Up2uqS4h/KRgHuoeGwBcD4Ng9SiP4dIRy0EXTlnuz47vAwmeGwVChigm" crossorigin="anonymous">
   <!-- Main scripts -->
   <script src="assets/js/script.js"></script>
 </body>


### PR DESCRIPTION
- Se actualiza la versión de FontAwesome de 5.0 a 5.15.4.

- En el footer se agrega links a redes sociales usando iconos FontAwesome.

- Se crea una clase llamada "fab-link" para dar estilo a las etiquetas <a> del footer con CSS.