### PR TITLE
agregando controles video en iframe youtube en sección video linea 131

### DIFF
--- a/index.html
+++ b/index.html
@@ -128,7 +128,7 @@
 
   <!-- Video -->
   <section class="embed-responsive embed-responsive-16by9 video">
-    <iframe class="embed-responsive-item" src="https://www.youtube.com/embed/ZGn8kSV9gAA?rel=0&amp;controls=0&amp;showinfo=0" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
+    <iframe class="embed-responsive-item" src="https://www.youtube.com/embed/ZGn8kSV9gAA?rel=0&amp;controls=1&amp;showinfo=0" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
     <div class="video__inner">
       <h2>Nuestros Exitos</h2>
       <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras ultrices accumsan ornare. Phasellus tristique ullamcorper luctus. Nunc varius ullamcorper felis. Nulla nibh ipsum, rutrum.</p>


### PR DESCRIPTION
Habilitamos los controles de video en el iframe de youtube para facilitar la navegación en la página y que el usuario pueda controlar el video.